### PR TITLE
Add views-config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ This scenario inlines the view defined in `MyView.sql`, with unused join strippi
 When a file path is specified for the main view, the tool uses the exact contents of that file. If a connection
 string is also supplied, any views referenced *within* `MyView.sql` are fetched from the database.
 
+### Adding multiple view definitions from a config file
+```
+sqlinliner -vp "./views/MyView.sql" -vc "./views/views.json"
+```
+
+Provide `--views-config` with a JSON file that maps view names to `.sql` files.
+All listed views are loaded before inlining so nested local views can be
+resolved. Example:
+
+```json
+{
+  "dbo.VPeople": "VPeople.sql",
+  "dbo.VNestedPeople": "VNestedPeople.sql"
+}
+```
+
 ### Disabling the CREATE OR ALTER wrapper
 ``sqlinliner -vp "./views/MyView.sql" --generate-create-or-alter false``
 
@@ -61,6 +77,7 @@ Two optional parameters can be used to control where the generated SQL and debug
 
 * `--output-path` (`-op`) – write the resulting SQL to the specified file instead of the console.
 * `--log-path` (`-lp`) – write warnings, errors and timing information to the given file. When not provided these details are written to the console.
+* `--views-config` (`-vc`) – JSON file mapping additional view names to their local SQL files.
 
 ## Verifying the generated code
 

--- a/src/SqlInliner.Tests/AdditionalTests.cs
+++ b/src/SqlInliner.Tests/AdditionalTests.cs
@@ -46,4 +46,18 @@ public class AdditionalTests
         Assert.IsNotNull(referenced.Alias);
         Assert.AreEqual("VPeople", referenced.Alias!.Value);
     }
+
+    [Test]
+    public void ParseObjectNameDefaultsSchema()
+    {
+        var name = DatabaseConnection.ParseObjectName("VTest");
+        Assert.AreEqual("[dbo].[VTest]", name.GetName());
+    }
+
+    [Test]
+    public void ParseObjectNameWithSchema()
+    {
+        var name = DatabaseConnection.ParseObjectName("custom.VTest");
+        Assert.AreEqual("[custom].[VTest]", name.GetName());
+    }
 }

--- a/src/SqlInliner/DatabaseConnection.cs
+++ b/src/SqlInliner/DatabaseConnection.cs
@@ -111,4 +111,18 @@ public sealed class DatabaseConnection
         objectName.Identifiers.Add(new() { Value = name });
         return objectName;
     }
+
+    /// <summary>
+    /// Parses a two-part view name (<c>schema.name</c>) into a
+    /// <see cref="SchemaObjectName"/> instance.
+    /// </summary>
+    public static SchemaObjectName ParseObjectName(string name)
+    {
+        var parts = name.Split('.', 2);
+        return parts.Length switch
+        {
+            1 => ToObjectName("dbo", parts[0]),
+            _ => ToObjectName(parts[0], parts[1]),
+        };
+    }
 }

--- a/src/SqlInliner/Program.cs
+++ b/src/SqlInliner/Program.cs
@@ -4,6 +4,8 @@ using Microsoft.Data.SqlClient;
 using System;
 using System.CommandLine;
 using System.IO;
+using System.Text.Json;
+using System.Collections.Generic;
 
 namespace SqlInliner;
 
@@ -16,6 +18,8 @@ internal static class Program
         var viewPathOption = new Option<FileInfo>(new[] { "--view-path", "-vp" }, "The path of the view as a .sql file (including create statement)");
         var stripUnusedColumnsOption = new Option<bool>(new[] { "--strip-unused-columns", "-suc" }, () => true);
         var stripUnusedJoinsOption = new Option<bool>(new[] { "--strip-unused-joins", "-suj" });
+        var viewsConfigOption = new Option<FileInfo?>(new[] { "--views-config", "-vc" },
+            "Optional path to a JSON file describing additional view definitions");
         var generateCreateOrAlterOption = new Option<bool>("--generate-create-or-alter", () => true);
         var outputPathOption = new Option<FileInfo?>(new[] { "--output-path", "-op" }, "Optional path of the file to write the resulting SQL to");
         var logPathOption = new Option<FileInfo?>(new[] { "--log-path", "-lp" }, "Optional path of the file to write debug information to");
@@ -29,11 +33,24 @@ internal static class Program
                 generateCreateOrAlterOption,
                 outputPathOption,
                 logPathOption,
+                viewsConfigOption,
                 // TODO: DatabaseView.parser (hardcoded to TSql150Parser)
             };
 
-        rootCommand.SetHandler((connectionString, viewName, viewPath, stripUnusedColumns, stripUnusedJoins, generateCreateOrAlter, outputPath, logPath) =>
+        rootCommand.SetHandler(context =>
         {
+            var parse = context.ParseResult;
+
+            var connectionString = parse.GetValueForOption(connectionStringOption)!;
+            var viewName = parse.GetValueForOption(viewNameOption);
+            var viewPath = parse.GetValueForOption(viewPathOption);
+            var stripUnusedColumns = parse.GetValueForOption(stripUnusedColumnsOption);
+            var stripUnusedJoins = parse.GetValueForOption(stripUnusedJoinsOption);
+            var generateCreateOrAlter = parse.GetValueForOption(generateCreateOrAlterOption);
+            var outputPath = parse.GetValueForOption(outputPathOption);
+            var logPath = parse.GetValueForOption(logPathOption);
+            var viewsConfig = parse.GetValueForOption(viewsConfigOption);
+
             var cs = new SqlConnectionStringBuilder(connectionString);
             if (!cs.ContainsKey(nameof(cs.ApplicationName)))
             {
@@ -42,6 +59,22 @@ internal static class Program
             }
 
             var connection = new DatabaseConnection(new SqlConnection(connectionString));
+
+            if (viewsConfig != null)
+            {
+                var baseDir = viewsConfig.Directory?.FullName ?? Environment.CurrentDirectory;
+                var data = File.ReadAllText(viewsConfig.FullName);
+                var views = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(data) ?? new();
+                foreach (var kvp in views)
+                {
+                    var path = kvp.Value;
+                    if (!Path.IsPathRooted(path))
+                        path = Path.Combine(baseDir, path);
+
+                    var sql = File.ReadAllText(path);
+                    connection.AddViewDefinition(DatabaseConnection.ParseObjectName(kvp.Key), sql);
+                }
+            }
 
             string viewSql;
             if (!string.IsNullOrEmpty(viewName))
@@ -74,7 +107,7 @@ internal static class Program
                 File.WriteAllText(logPath.FullName, log);
             }
             //return inliner.Errors.Count > 0 ? -1 : 0;
-        }, connectionStringOption, viewNameOption, viewPathOption, stripUnusedColumnsOption, stripUnusedJoinsOption, generateCreateOrAlterOption, outputPathOption, logPathOption);
+        });
 
         return rootCommand.Invoke(args);
     }


### PR DESCRIPTION
## Summary
- allow parsing of object names from strings
- support providing additional view definitions via JSON config file
- document the new option and usage
- test view name parsing

## Testing
- `dotnet test -v n`